### PR TITLE
[Feature] 로그인 시 유저 타입값을 로컬 스토리지에 저장

### DIFF
--- a/lib/model/network/api_manager.dart
+++ b/lib/model/network/api_manager.dart
@@ -87,6 +87,12 @@ class APIManager {
     };
   }
 
+  void writeUserType(String type) async {
+    await storage.write(key: USER_TYPE, value: type);
+    // final saved_type = await storage.read(key: USER_TYPE);
+    // print('유저 타입 -> ${saved_type}');
+  }
+
   Future<bool> checkToken() async {
     final refreshToken = await storage.read(key: REFRESH_TOKEN_KEY);
     final accessToken = await storage.read(key: ACCESS_TOKEN_KEY);

--- a/lib/presenter/auth/login_service.dart
+++ b/lib/presenter/auth/login_service.dart
@@ -26,6 +26,7 @@ class LoginService {
     if (response != null) {
       final data = LoginModel.fromJson(response);
       APIManager().writeToken(data.data.accessToken, data.data.refreshToken);
+      APIManager().writeUserType(data.data.type);
       return true;
     }
     else { return false; }


### PR DESCRIPTION
## 📚 이슈 번호
#41 

## 💬 기타 사항
- 로컬에 저장된 유저 타입값 불러오기는 아래 스샷 중 주석처리 한 부분 참고해주세용(api_manager.dart 파일 내에 있습니당)
<img width="584" alt="스크린샷 2023-08-26 오후 9 00 51" src="https://github.com/PSR-Co/FRONTEND/assets/49021999/0a45516d-b661-4f4e-aab6-6248f7adbf66">

